### PR TITLE
[561365] Richtext can save previous description into the current element

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/internal/ListenerInstaller.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/internal/ListenerInstaller.java
@@ -257,7 +257,7 @@ public class ListenerInstaller {
 		/**
 		 * Notice that firePropertyChangeEvent() javascript function is defined MDERichTextEditor.
 		 */
-		script.append("CKEDITOR.instances.editor.on('change', function () {");
+		script.append("CKEDITOR.instances.editor.on('key', function () {");
 		script.append("firePropertyChangeEvent();");
 		script.append("});");
 


### PR DESCRIPTION
Bug: 561365
Change-Id: I77ba983743289f89d91444de5665eace165620f1
Signed-off-by: Sandu Postaru <sandu.postaru@thalesgroup.com>