### PR TITLE
[566612][Richtext] After being refreshed, the editor does not have all the listeners

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
@@ -264,5 +264,7 @@ public interface MDERichTextWidget extends PropertyChangeListener {
 	void setIsLoading(boolean isLoading);
 
 	boolean isLoading();
+	
+	public void installListenersOnReadyInstance();
 
 }

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
@@ -169,7 +169,7 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 	/**
 	 * Install listener on ready instance event fired by ckEditor
 	 */
-	protected void installListenersOnReadyInstance() {
+	public void installListenersOnReadyInstance() {
 		// This method is intended to be overriden by sub-classes to add
 		// listeners to CKEditor
 		// or adding generic listener here.

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget.tools/src/org/polarsys/kitalpha/richtext/widget/tools/handlers/RefreshHandler.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget.tools/src/org/polarsys/kitalpha/richtext/widget/tools/handlers/RefreshHandler.java
@@ -18,6 +18,7 @@ public class RefreshHandler implements MDERichTextToolbarItemHandler {
 	@Override
 	public void execute(MDERichTextWidget richText) {
 		richText.updateEditor();
+		richText.installListenersOnReadyInstance();
 	}
 
 }

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/MDERichtextWidgetEditorImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/MDERichtextWidgetEditorImpl.java
@@ -41,7 +41,7 @@ public class MDERichtextWidgetEditorImpl extends MDENebulaBasedRichTextWidgetImp
 	}
 
 	@Override
-	protected void installListenersOnReadyInstance() {
+	public void installListenersOnReadyInstance() {
 		super.installListenersOnReadyInstance();
 
 		installer.createAllListeners(this);

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/MDERichtextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/MDERichtextWidgetImpl.java
@@ -41,7 +41,7 @@ public class MDERichtextWidgetImpl extends MDENebulaBasedRichTextWidgetImpl {
 	}
 
 	@Override
-	protected void installListenersOnReadyInstance() {
+	public void installListenersOnReadyInstance() {
 		super.installListenersOnReadyInstance();
 
 		installer.createAllListeners(this);


### PR DESCRIPTION
CKEditor after being refreshed removes all its listeners. The refresh action must add all listerners again to the newly refreshed editor.

Bug: 566612
Change-Id: I17c4245f3075285cc411a14270e796c389ea6f04
Signed-off-by: Tu Ton <minhtutonthat@gmail.com>