### PR TITLE
[567500] Revert Scoping data cleaning

### DIFF
--- a/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore
+++ b/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/egf/HTMLDocGenCommon.fcore
@@ -384,7 +384,7 @@
         </invocationContractContainer>
       </invocations>
       <invocations xmi:id="_Lg8PAAyDEeuATuFqNvKAVw" name="Initialize Registry Data"
-          invokedActivity="#_v1xvkUHPEeWuloZZIJtB0g"/>
+          invokedActivity="#_UcyBgB9vEeuxOqSqip439A"/>
       <invocations xmi:id="_Ueu3MJ2OEemJ2K-s0Y7hRg" name="load page extensions runtime parameters"
           invokedActivity="#_DPcgsJ2OEemJ2K-s0Y7hRg">
         <invocationContractContainer xmi:id="_Ueu3MZ2OEemJ2K-s0Y7hRg">
@@ -515,6 +515,8 @@
         </invocationContractContainer>
       </invocations>
       <invocations xmi:id="_FbkMQEHQEeWuloZZIJtB0g" name="Clean Scope Data" invokedActivity="#_v1xvkUHPEeWuloZZIJtB0g"/>
+      <invocations xmi:id="_bMmIcB9vEeuxOqSqip439A" name="Initialize Registry Data"
+          invokedActivity="#_UcyBgB9vEeuxOqSqip439A"/>
     </orchestration>
   </fcore:FactoryComponent>
   <fcore:FactoryComponent xmi:id="_NFDG8Of_Ed-RW5fqwaBgOQ" name="HTMLDocGen.Index builder">
@@ -1059,6 +1061,8 @@
       kind="java" implementation="org.polarsys.kitalpha.doc.gen.business.core.task.RemoveCollectedConceptForSearchIndex"/>
   <ftask:Task xmi:id="_v1xvkUHPEeWuloZZIJtB0g" name="Clean.Scope.Data" kind="java"
       implementation="org.polarsys.kitalpha.doc.gen.business.core.task.CleanScopeDataTask"/>
+  <ftask:Task xmi:id="_UcyBgB9vEeuxOqSqip439A" name="Clean.Registry.Data" kind="java"
+      implementation="org.polarsys.kitalpha.doc.gen.business.core.task.CleanRegistryDataTask"/>
   <ftask:Task xmi:id="_DPcgsJ2OEemJ2K-s0Y7hRg" name="load.page.extension.runtime.parameters"
       kind="java" implementation="org.polarsys.kitalpha.doc.gen.business.core.task.LoadPageExtensionRuntimeParameters">
     <contractContainer xmi:id="_N9pIwJ2OEemJ2K-s0Y7hRg">

--- a/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/src/org/polarsys/kitalpha/doc/gen/business/core/task/CleanRegistryDataTask.java
+++ b/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/src/org/polarsys/kitalpha/doc/gen/business/core/task/CleanRegistryDataTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2020 Thales Global Services S.A.S.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -14,13 +14,12 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.egf.core.producer.InvocationException;
 import org.eclipse.egf.ftask.producer.context.ITaskProductionContext;
 import org.eclipse.egf.ftask.producer.invocation.ITaskProduction;
-import org.polarsys.kitalpha.doc.gen.business.core.scope.GenerationGlobalScope;
 import org.polarsys.kitalpha.doc.gen.business.core.sirius.util.diagram.DiagramExportRegistry;
 
 /**
- * @author Boubekeur Zendagui
+ * @author Arnaud Dieumegard
  */
-public class CleanScopeDataTask implements ITaskProduction {
+public class CleanRegistryDataTask implements ITaskProduction {
 
 	@Override
 	public void preExecute(ITaskProductionContext productionContext,
@@ -31,7 +30,7 @@ public class CleanScopeDataTask implements ITaskProduction {
 	@Override
 	public void doExecute(ITaskProductionContext productionContext,
 			IProgressMonitor monitor) throws InvocationException {
-		GenerationGlobalScope.getInstance().cleanScope();
+		DiagramExportRegistry.getInstance().clean();
 	}
 
 	@Override


### PR DESCRIPTION
- Revert scoping data cleaning task to it original state (not called at
the beginning of the production plan).
- Separate DiagramExportRegistry cleaning to dedicated task and call at
beginning and end of production plan.

Bug: 567500
Change-Id: I1e055f0a3eb6eb3dcc5789d1503e18589049c64b
Signed-off-by: Arnaud Dieumegard <arnaud.dieumegard@obeo.fr>