### PR TITLE
Update eclipse-jarsigner-plugin version

### DIFF
--- a/releng/plugins/org.polarsys.kitalpha.releng.parent/pom.xml
+++ b/releng/plugins/org.polarsys.kitalpha.releng.parent/pom.xml
@@ -107,7 +107,7 @@
 					<plugin>
 						<groupId>org.eclipse.cbi.maven.plugins</groupId>
 						<artifactId>eclipse-jarsigner-plugin</artifactId>
-						<version>1.1.5</version>
+						<version>1.3.2</version>
 						<executions>
 							<execution>
 								<id>sign</id>


### PR DESCRIPTION
Modifies used version of the eclipse-jarsigner-plugin.
The branch build does not sign jars (see Jenkinsfile), so the first version of the PR force the jar signing (see build: https://ci.eclipse.org/kitalpha/job/Kitalpha/job/PR-682/2/) while the second version reverts the Jenkinsfile to keep PR to not sign jars. 
This is this last version that should be merged.