### PR TITLE
#677 Migration to Eclipse 2021-06 - Step 2

### DIFF
--- a/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.target
+++ b/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.target
@@ -1,8 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="kitalpha" sequenceNumber="1627295136">
+<target name="kitalpha" sequenceNumber="1629817553">
   <locations>
+    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
+      <unit id="org.apache.log4j" version="0.0.0"/>
+      <unit id="org.easymock" version="0.0.0"/>
+      <unit id="org.hamcrest.library" version="0.0.0"/>
+      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
+      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
+      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
+      <unit id="ch.qos.logback.classic" version="1.0.7.v20121108-1250"/>
+      <unit id="ch.qos.logback.core" version="1.0.7.v20121108-1250"/>
+      <unit id="org.apache.xalan" version="2.7.2.v20201124-1837"/>
+      <unit id="org.antlr.runtime" version="4.7.1.v20181120-0808"/>
+      <unit id="org.apache.batik.ext" version="1.14.0.v20210324-0332"/>
+      <unit id="org.apache.batik.codec" version="1.14.0.v20210324-0332"/>
+      <unit id="org.apache.batik.bridge" version="1.14.0.v20210324-0332"/>
+      <unit id="org.apache.batik.script" version="1.14.0.v20210324-0332"/>
+      <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
+    </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
       <unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="3.1.0.202106041005"/>
@@ -191,19 +208,19 @@
       <unit id="org.eclipse.emf.diffmerge.gmf.feature.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.egit.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.egit.feature.source.feature.group" version="0.0.0"/>
-      <repository id="EMF-DiffMerge" location="https://download.eclipse.org/diffmerge/releases/0.13.1/emf-diffmerge-site/"/>
+      <repository id="EMF-DiffMerge" location="https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/emf-diffmerge-site/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.diffmerge.patterns.sdk.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.patterns.sdk.feature.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.source.feature.group" version="0.0.0"/>
-      <repository id="EDM-Patterns" location="https://download.eclipse.org/diffmerge/releases/0.13.1/edm-patterns-site/"/>
+      <repository id="EDM-Patterns" location="https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/edm-patterns-site/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emf.diffmerge.coevolution.sdk.feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.diffmerge.coevolution.sdk.feature.source.feature.group" version="0.0.0"/>
-      <repository id="coevolution" location="https://download.eclipse.org/diffmerge/releases/0.13.1/edm-coevolution-site/"/>
+      <repository id="coevolution" location="https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/edm-coevolution-site/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.amalgam.explorer.activity.feature.group" version="0.0.0"/>
@@ -214,7 +231,7 @@
       <unit id="org.eclipse.amalgam.explorer.contextual.sirius.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.amalgam.explorer.contextual.core.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.amalgam.explorer.contextual.core.source.feature.group" version="0.0.0"/>
-      <repository id="amalgam" location="https://download.eclipse.org/modeling/amalgam/updates/stable/1.12.1-S20210330/capella"/>
+      <repository id="amalgam" location="https://download.eclipse.org/modeling/amalgam/updates/stable/1.13.0-S20210824/capella"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.egf.sdk.feature.feature.group" version="0.0.0"/>
@@ -233,21 +250,7 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="ca.odell.glazedlists" version="0.0.0"/>
-      <unit id="org.apache.log4j" version="0.0.0"/>
-      <unit id="org.easymock" version="0.0.0"/>
-      <unit id="org.hamcrest.library" version="0.0.0"/>
-      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
-      <unit id="ch.qos.logback.classic" version="1.0.7.v20121108-1250"/>
-      <unit id="ch.qos.logback.core" version="1.0.7.v20121108-1250"/>
-      <unit id="org.apache.xalan" version="2.7.2.v20201124-1837"/>
-      <unit id="org.antlr.runtime" version="4.7.1.v20181120-0808"/>
-      <unit id="org.apache.batik.ext" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.codec" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.bridge" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.script" version="1.14.0.v20210324-0332"/>
-      <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
+      <repository id="Orbit2s" location="https://download.eclipse.org/tools/orbit/downloads/2021-06"/>
     </location>
   </locations>
 </target>

--- a/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.target
+++ b/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.target
@@ -1,69 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="kitalpha" sequenceNumber="1629817553">
+<target name="kitalpha" sequenceNumber="1629887077">
   <locations>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.apache.log4j" version="0.0.0"/>
-      <unit id="org.easymock" version="0.0.0"/>
-      <unit id="org.hamcrest.library" version="0.0.0"/>
-      <unit id="org.junit" version="4.13.0.v20200204-1500"/>
-      <unit id="org.slf4j.api" version="1.7.2.v20121108-1250"/>
-      <unit id="ch.qos.logback.slf4j" version="1.0.7.v201505121915"/>
-      <unit id="ch.qos.logback.classic" version="1.0.7.v20121108-1250"/>
-      <unit id="ch.qos.logback.core" version="1.0.7.v20121108-1250"/>
-      <unit id="org.apache.xalan" version="2.7.2.v20201124-1837"/>
-      <unit id="org.antlr.runtime" version="4.7.1.v20181120-0808"/>
-      <unit id="org.apache.batik.ext" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.codec" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.bridge" version="1.14.0.v20210324-0332"/>
-      <unit id="org.apache.batik.script" version="1.14.0.v20210324-0332"/>
-      <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.swtbot.eclipse.feature.group" version="3.1.0.202106041005"/>
-      <unit id="org.eclipse.swtbot.eclipse.gef.feature.group" version="3.1.0.202106041005"/>
-      <unit id="org.eclipse.swtbot.feature.group" version="3.1.0.202106041005"/>
-      <unit id="org.eclipse.swtbot.forms.feature.group" version="3.1.0.202106041005"/>
-      <unit id="org.eclipse.swtbot.ide.feature.group" version="3.1.0.202106041005"/>
-      <repository id="SWTBot-3_1" location="https://download.eclipse.org/technology/swtbot/releases/3.1.0/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.license.feature.group" version="0.0.0"/>
-      <repository id="Eclipse-Shared-License" location="https://download.eclipse.org/cbi/updates/license"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.acceleo.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.ide.ui" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.ui.interpreter.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.ui.interpreter.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.query.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.query.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.query.ui.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.acceleo.query.ui.source.feature.group" version="0.0.0"/>
-      <unit id="org.antlr.runtime" version="4.7.2.v20200218-0804"/>
-      <repository id="Acceleo-3.7" location="https://download.eclipse.org/acceleo/updates/releases/3.7/R202102190929"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.eef.sdk.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.eef.sdk.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.eef.ext.widgets.reference.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.eef.ext.widgets.reference.feature.source.feature.group" version="0.0.0"/>
-      <repository id="EEF-2.1.5" location="https://download.eclipse.org/modeling/emft/eef/updates/releases/2.1/R202008270808"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.elk.sdk.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.sdk.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.algorithms.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.algorithms.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.graphviz.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.graphviz.feature.source.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.ui.feature.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.elk.ui.feature.source.feature.group" version="0.0.0"/>
-      <repository id="ELK-0.7" location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
-    </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.gmf.runtime.notation.sdk.feature.group" version="0.0.0"/>
       <repository id="GMF-Notation-1.13.0" location="https://download.eclipse.org/modeling/gmp/gmf-notation/updates/releases/R202004160913"/>
@@ -74,17 +13,16 @@
       <repository id="GMF-Runtime-1.14.0" location="https://download.eclipse.org/modeling/gmp/gmf-runtime/updates/releases/R202107090702/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.sirius.common.interpreter" version="0.0.0"/>
-      <repository id="Sirius-6.5.0" location="https://download.eclipse.org/sirius/updates/releases/6.5.0/2020-06/"/>
-    </location>
-    <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.egit.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.equinox.executable.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.validation.ocl" version="0.0.0"/>
+      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.transaction.doc.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.gmf.runtime.notation.sdk" version="0.0.0"/>
-      <unit id="org.eclipse.gmf.runtime.notation.source" version="0.0.0"/>
+      <unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ui.ide" version="0.0.0"/>
       <unit id="org.eclipse.ui.workbench" version="0.0.0"/>
       <unit id="lpg.runtime.java.source" version="0.0.0"/>
@@ -97,6 +35,7 @@
       <unit id="org.eclipse.xtend.typesystem.emf.source" version="0.0.0"/>
       <unit id="org.eclipse.emf.mwe.utils.source" version="0.0.0"/>
       <unit id="org.eclipse.emf.mwe2.runtime.source" version="0.0.0"/>
+      <unit id="org.eclipse.draw2d.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.draw2d.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.e4.rcp.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.ecf.core.feature.feature.group" version="0.0.0"/>
@@ -113,6 +52,7 @@
       <unit id="org.eclipse.help.source" version="0.0.0"/>
       <unit id="org.eclipse.jdt.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.jgit" version="0.0.0"/>
+      <unit id="org.eclipse.ocl.all.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.cvs.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.pde.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.platform.source" version="0.0.0"/>
@@ -125,6 +65,7 @@
       <unit id="org.eclipse.xsd.mapping.source.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xsd.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xsd.source" version="0.0.0"/>
+      <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xtext.docs.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.xtext.ui.source" version="0.0.0"/>
       <unit id="org.eclipse.xtext.xbase.lib.source" version="0.0.0"/>
@@ -133,35 +74,9 @@
       <unit id="org.eclipse.emf.eef.sdk-feature.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.ecoretools.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.ecoretools.design.feature.group" version="0.0.0"/>
+      <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.emf.cdo.feature.group" version="0.0.0"/>
       <unit id="org.eclipse.collections.feature.source.feature.group" version="0.0.0"/>
-      <unit id="com.google.guava" version="0.0.0"/>
-      <unit id="com.ibm.icu" version="0.0.0"/>
-      <unit id="org.eclipse.draw2d.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.common.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.compare.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.ecore.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.edit.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.eef.runtime" version="0.0.0"/>
-      <unit id="org.eclipse.emf.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.mwe.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.transaction.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.transaction.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.validation.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.emf.workspace.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.equinox.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.gef.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.gef.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.ocl.all.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.ocl.core.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.uml2.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.xpand.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
-      <unit id="org.eclipse.xtext.sdk.feature.group" version="0.0.0"/>
       <repository id="Eclipse-2021-06" location="https://download.eclipse.org/releases/2021-06/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
@@ -250,7 +165,9 @@
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="ca.odell.glazedlists" version="0.0.0"/>
-      <repository id="Orbit2s" location="https://download.eclipse.org/tools/orbit/downloads/2021-06"/>
+      <unit id="org.apache.batik.bridge.source" version="0.0.0"/>
+      <unit id="org.apache.batik.script.source" version="0.0.0"/>
+      <repository id="Orbit" location="https://download.eclipse.org/tools/orbit/downloads/2021-06"/>
     </location>
   </locations>
 </target>

--- a/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.targetplatform
+++ b/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.targetplatform
@@ -11,16 +11,19 @@
  *******************************************************************************/
 target "kitalpha" with source, requirements
 
-include "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210722-123507/2021-06/targets/sirius_2021-06.targetplatform"
+include "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210722-123507/2021-06/targets/modules/gmf-runtime-1.14.tpd"
 
 location Eclipse-2021-06 "https://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.m2e.feature.feature.group lazy
+	org.eclipse.sdk.feature.group lazy
 	org.eclipse.egit.feature.group lazy
 	org.eclipse.equinox.executable.feature.group lazy
+	org.eclipse.uml2.sdk.feature.group lazy
+	org.eclipse.xtext.sdk.feature.group lazy
 	org.eclipse.emf.validation.ocl lazy
+	org.eclipse.emf.transaction.sdk.feature.group lazy
 	org.eclipse.emf.transaction.doc.feature.group lazy
-	org.eclipse.gmf.runtime.notation.sdk lazy
-	org.eclipse.gmf.runtime.notation.source lazy
+	org.eclipse.gef.sdk.feature.group lazy
 	org.eclipse.ui.ide lazy
 	org.eclipse.ui.workbench lazy
 	lpg.runtime.java.source lazy
@@ -33,6 +36,7 @@ location Eclipse-2021-06 "https://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.xtend.typesystem.emf.source lazy
 	org.eclipse.emf.mwe.utils.source lazy
 	org.eclipse.emf.mwe2.runtime.source lazy
+	org.eclipse.draw2d.sdk.feature.group lazy
 	org.eclipse.draw2d.source.feature.group lazy
 	org.eclipse.e4.rcp.source.feature.group lazy
 	org.eclipse.ecf.core.feature.feature.group lazy
@@ -49,6 +53,7 @@ location Eclipse-2021-06 "https://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.help.source lazy
 	org.eclipse.jdt.source.feature.group lazy
 	org.eclipse.jgit lazy
+	org.eclipse.ocl.all.feature.group lazy
 	org.eclipse.cvs.feature.group lazy
 	org.eclipse.pde.source.feature.group lazy
 	org.eclipse.platform.source lazy
@@ -61,6 +66,7 @@ location Eclipse-2021-06 "https://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.xsd.mapping.source.feature.group lazy
 	org.eclipse.xsd.sdk.feature.group lazy
 	org.eclipse.xsd.source lazy
+	org.eclipse.xtend.sdk.feature.group lazy
 	org.eclipse.xtext.docs.feature.group lazy
 	org.eclipse.xtext.ui.source lazy
 	org.eclipse.xtext.xbase.lib.source lazy
@@ -69,6 +75,7 @@ location Eclipse-2021-06 "https://download.eclipse.org/releases/2021-06/" {
 	org.eclipse.emf.eef.sdk-feature.feature.group lazy
 	org.eclipse.emf.ecoretools.sdk.feature.group lazy
 	org.eclipse.emf.ecoretools.design.feature.group lazy
+	org.eclipse.emf.sdk.feature.group lazy
 	org.eclipse.emf.cdo.feature.group lazy
 	org.eclipse.collections.feature.source.feature.group lazy
 }
@@ -159,6 +166,8 @@ location Nattable "https://download.eclipse.org/nattable/releases/2.0.1/reposito
 	org.eclipse.nebula.widgets.nattable.extension.glazedlists.feature.feature.group lazy
 }
 
-location Orbit2 "https://download.eclipse.org/tools/orbit/downloads/2021-06" {
+location Orbit "https://download.eclipse.org/tools/orbit/downloads/2021-06" {
 	ca.odell.glazedlists lazy
+	org.apache.batik.bridge.source lazy
+	org.apache.batik.script.source lazy
 }

--- a/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.targetplatform
+++ b/releng/plugins/org.polarsys.kitalpha.releng.targets/kitalpha.targetplatform
@@ -110,7 +110,7 @@ location sirius "https://download.eclipse.org/sirius/updates/stable/7.0.0-S20210
 	org.eclipse.sirius.specifier.feature.group lazy
 }
 
-location EMF-DiffMerge "https://download.eclipse.org/diffmerge/releases/0.13.1/emf-diffmerge-site/" {
+location EMF-DiffMerge "https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/emf-diffmerge-site/" {
 	org.eclipse.emf.diffmerge.feature.feature.group lazy
 	org.eclipse.emf.diffmerge.feature.source.feature.group lazy
 	org.eclipse.emf.diffmerge.sirius.feature.feature.group lazy
@@ -121,19 +121,19 @@ location EMF-DiffMerge "https://download.eclipse.org/diffmerge/releases/0.13.1/e
 	org.eclipse.emf.diffmerge.egit.feature.source.feature.group lazy
 }
 
-location EDM-Patterns "https://download.eclipse.org/diffmerge/releases/0.13.1/edm-patterns-site/" {
+location EDM-Patterns "https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/edm-patterns-site/" {
 	org.eclipse.emf.diffmerge.patterns.sdk.feature.feature.group lazy
 	org.eclipse.emf.diffmerge.patterns.sdk.feature.source.feature.group lazy
 	org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.feature.group lazy
 	org.eclipse.emf.diffmerge.patterns.sirius.sdk.feature.source.feature.group lazy
 }
 
-location coevolution "https://download.eclipse.org/diffmerge/releases/0.13.1/edm-coevolution-site/" {
+location coevolution "https://download.eclipse.org/diffmerge/stable/0.14.0-S20210823/edm-coevolution-site/" {
 	 org.eclipse.emf.diffmerge.coevolution.sdk.feature.feature.group lazy
 	 org.eclipse.emf.diffmerge.coevolution.sdk.feature.source.feature.group lazy
 }
 
-location amalgam "https://download.eclipse.org/modeling/amalgam/updates/stable/1.12.1-S20210330/capella" {
+location amalgam "https://download.eclipse.org/modeling/amalgam/updates/stable/1.13.0-S20210824/capella" {
 	org.eclipse.amalgam.explorer.activity.feature.group lazy
 	org.eclipse.amalgam.explorer.activity.source.feature.group lazy
 	org.eclipse.amalgam.explorer.contextual.feature.group lazy
@@ -159,6 +159,6 @@ location Nattable "https://download.eclipse.org/nattable/releases/2.0.1/reposito
 	org.eclipse.nebula.widgets.nattable.extension.glazedlists.feature.feature.group lazy
 }
 
-location Orbit "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository" {
+location Orbit2 "https://download.eclipse.org/tools/orbit/downloads/2021-06" {
 	ca.odell.glazedlists lazy
 }


### PR DESCRIPTION
- EMF DiffMerge
- Amalgam
- Set target platform similar to 5.1.x branch. Using some artifacts from
Sirius target plugins but not all of them were mixing plugins. Its more
consistent to have all the plugins from one cots to the same repository

Change-Id: Ibf762278bf985b8b59fe6419178c257a0f54e265
Signed-off-by: Philippe DUL <philippe.dul@thalesgroup.com>