### PR TITLE
 #720 Improve RotativeImage performances

### DIFF
--- a/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/editpart/RotativeImageEditPart.java
+++ b/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/editpart/RotativeImageEditPart.java
@@ -14,7 +14,6 @@ package org.polarsys.kitalpha.sirius.rotativeimage.editpart;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-import org.eclipse.draw2d.AncestorListener;
 import org.eclipse.draw2d.FigureListener;
 import org.eclipse.draw2d.IFigure;
 import org.eclipse.draw2d.PositionConstants;
@@ -79,7 +78,7 @@ public class RotativeImageEditPart extends WorkspaceImageEditPart implements ISt
             
             primaryShape = getWorkspaceImageFigure(wkImage, workspacePath, desc);
             SwitchImageListener switchImageListener = new SwitchImageListener(this);
-            primaryShape.addAncestorListener(switchImageListener);
+            primaryShape.addFigureListener(switchImageListener);
             primaryShape.addPropertyChangeListener(switchImageListener);
             
             EditPart parent = this.getParent();
@@ -101,7 +100,7 @@ public class RotativeImageEditPart extends WorkspaceImageEditPart implements ISt
 		} else {
 		    // RotativeDescription.FOUR_IMAGES mode
 		    if (WorkspaceImageFigure.isSvgImage(description.id)) {
-		    	figure = Rotative4ImagesSVGWorkspaceImageFigure.createImageFigures(workspaceImage, workspacePath);
+		    	figure = Rotative4ImagesSVGWorkspaceImageFigure.createImageFigure(workspaceImage, workspacePath);
 		    } else {
 		        RotativeWorkspaceImageHelper.createImage(description.id, PositionConstants.NORTH);
 		        RotativeWorkspaceImageHelper.createImage(description.id, PositionConstants.WEST);
@@ -113,25 +112,13 @@ public class RotativeImageEditPart extends WorkspaceImageEditPart implements ISt
 		return figure;
 	}
 
-    private static class SwitchImageListener implements AncestorListener, PropertyChangeListener, FigureListener {
+    private static class SwitchImageListener implements PropertyChangeListener, FigureListener {
 
         private RotativeImageEditPart editPart;
 
         public SwitchImageListener(final RotativeImageEditPart editPart) {
             this.editPart = editPart;
 
-        }
-
-        public void ancestorAdded(IFigure ancestor) {
-            updateImage();
-        }
-
-        public void ancestorMoved(IFigure ancestor) {
-            updateImage();
-        }
-
-        public void ancestorRemoved(IFigure ancestor) {
-            updateImage();
         }
 
         public void propertyChange(PropertyChangeEvent arg0) {

--- a/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/figures/Rotative4ImagesSVGWorkspaceImageFigure.java
+++ b/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/figures/Rotative4ImagesSVGWorkspaceImageFigure.java
@@ -12,8 +12,6 @@
  *******************************************************************************/
 package org.polarsys.kitalpha.sirius.rotativeimage.figures;
 
-import java.util.HashMap;
-
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.sirius.diagram.WorkspaceImage;
 import org.eclipse.sirius.diagram.ui.tools.api.figure.SVGWorkspaceImageFigure;

--- a/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/figures/Rotative4ImagesSVGWorkspaceImageFigure.java
+++ b/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/figures/Rotative4ImagesSVGWorkspaceImageFigure.java
@@ -12,6 +12,8 @@
  *******************************************************************************/
 package org.polarsys.kitalpha.sirius.rotativeimage.figures;
 
+import java.util.HashMap;
+
 import org.eclipse.draw2d.PositionConstants;
 import org.eclipse.sirius.diagram.WorkspaceImage;
 import org.eclipse.sirius.diagram.ui.tools.api.figure.SVGWorkspaceImageFigure;
@@ -39,17 +41,10 @@ public class Rotative4ImagesSVGWorkspaceImageFigure extends SVGWorkspaceImageFig
 		super();
 	}
 
-	public static Rotative4ImagesSVGWorkspaceImageFigure createImageFigures(final WorkspaceImage image, String basepath) {
-		Rotative4ImagesSVGWorkspaceImageFigure topFigure = Rotative4ImagesSVGWorkspaceImageFigure.createImageFigure(image, basepath, PositionConstants.NORTH);
-		Rotative4ImagesSVGWorkspaceImageFigure.createImageFigure(image, basepath, PositionConstants.SOUTH);
-		Rotative4ImagesSVGWorkspaceImageFigure.createImageFigure(image, basepath, PositionConstants.EAST);
-		Rotative4ImagesSVGWorkspaceImageFigure.createImageFigure(image, basepath, PositionConstants.WEST);
-		return topFigure;
-	}
-
-	public static Rotative4ImagesSVGWorkspaceImageFigure createImageFigure(WorkspaceImage image, String basepath, int orientation) {
+	public static Rotative4ImagesSVGWorkspaceImageFigure createImageFigure(WorkspaceImage image, String basepath) {
 		Rotative4ImagesSVGWorkspaceImageFigure figure = new Rotative4ImagesSVGWorkspaceImageFigure();
-		figure.orientation = orientation;
+		// Set default orientation (will be changed with calls to setOrientation)
+		figure.orientation = PositionConstants.NORTH;
 		figure.basepath = basepath;
 		figure.refreshFigure(image);
 		return figure;
@@ -63,9 +58,11 @@ public class Rotative4ImagesSVGWorkspaceImageFigure extends SVGWorkspaceImageFig
 	 */
 	@Override
 	public void refreshFigure(final WorkspaceImage workspaceImage) {
-		String uri = RotativeWorkspaceImageHelper.get4ImagesDocumentKey(basepath, orientation);
-		this.setURI(uri);
-		this.contentChanged();
+	    String documentKey = this.getDocumentKey();
+	    if (!documentKey.equals(this.getURI())) {
+	        this.setURI(this.getDocumentKey(), false);
+	        this.contentChanged();
+	    }
 	}
 
 	/**
@@ -74,9 +71,10 @@ public class Rotative4ImagesSVGWorkspaceImageFigure extends SVGWorkspaceImageFig
 	 *            PositionConstants.NORTH
 	 */
 	public void setOrientation(int orientation) {
-		this.orientation = orientation;
-		this.setURI(this.getDocumentKey());
-		this.contentChanged();
+	    if (this.orientation != orientation) {
+    		this.orientation = orientation;
+    		refreshFigure(null);
+	    }
 	}
 
 	@Override

--- a/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/internal/helpers/RotativeWorkspaceImageHelper.java
+++ b/sirius/plugins/org.polarsys.kitalpha.sirius.rotativeimage/src/org/polarsys/kitalpha/sirius/rotativeimage/internal/helpers/RotativeWorkspaceImageHelper.java
@@ -13,6 +13,7 @@
 package org.polarsys.kitalpha.sirius.rotativeimage.internal.helpers;
 
 import java.io.File;
+import java.util.HashMap;
 
 import org.eclipse.core.runtime.Path;
 import org.eclipse.draw2d.PositionConstants;
@@ -28,6 +29,8 @@ import org.polarsys.kitalpha.sirius.rotativeimage.Activator;
  * An utility class to create rotated images and access them. It stores images in the ImageRegistry of this plugin
  */
 public class RotativeWorkspaceImageHelper {
+    
+    private static HashMap<String, String> IMAGE_PATHS_CACHE = new HashMap<>();
 
 	private RotativeWorkspaceImageHelper() {
 		throw new IllegalStateException("Utility class");
@@ -79,11 +82,15 @@ public class RotativeWorkspaceImageHelper {
 	}
 
 	public static String get4ImagesDocumentKey(String path, int orientation) {
-		String result = getImageURI(getOrientedPath(path, orientation));
-		if (result == null) {
-			// Default to original file path
-			result = getImageURI(path);
-		}
+        String result = IMAGE_PATHS_CACHE.get(path+orientation);
+        if (result == null) {
+            result = getImageURI(getOrientedPath(path, orientation));
+            if (result == null) {
+                // Default to original file path
+                result = getImageURI(path);
+            }
+            IMAGE_PATHS_CACHE.put(path+orientation, result);
+        }
 		return result;
 	}
 
@@ -123,7 +130,7 @@ public class RotativeWorkspaceImageHelper {
 
 	private static String getImageURI(String basepath) {
 		final File imageFile = FileProvider.getDefault().getFile(new Path(basepath));
-		if (imageFile != null && imageFile.exists() && imageFile.canRead()) {
+		if (imageFile != null) {
 			return imageFile.toURI().toString();
 		}
 		return null;


### PR DESCRIPTION
Removed calls to SVGFigure.contentChanged() in refreshFigure and
setOrientation to prevent multiple calls to svg library.
Removed AncestorListener and added FigureListener to Rotative
WorkspaceImageFigure to prevent repetitive and unnecessary figure updates.