### PR TITLE
#734 Viewpoint activation state fix 

### DIFF
--- a/emde/plugins/org.polarsys.kitalpha.emde/src/org/polarsys/kitalpha/emde/extension/preferences/PreferenceModelExtensionManager.java
+++ b/emde/plugins/org.polarsys.kitalpha.emde/src/org/polarsys/kitalpha/emde/extension/preferences/PreferenceModelExtensionManager.java
@@ -44,7 +44,7 @@ public class PreferenceModelExtensionManager extends DefaultModelExtensionManage
 
 	@Override
 	public boolean isExtensionModelDisabled(ExtendedModel extendedModel) {
-		return getPreferencesRoot().getBoolean(computeKey(extendedModel), false);
+		return getPreferencesRoot().getBoolean(computeKey(extendedModel), true);
 	}
 
 	protected String computeKey(ExtendedModel extendedModel) {


### PR DESCRIPTION
Changed default value returned when not finding a preference for the activation state of a given model.

New default value is true.
This means that, if a preference is not found, the extension model is considered disabled (and not enabled as it used to )