### PR TITLE
#753 Update the RichText editor status properly

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/impl/AbstractMDERichTextWidget.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/impl/AbstractMDERichTextWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -129,18 +129,6 @@ public abstract class AbstractMDERichTextWidget implements MDERichTextWidget {
 	public final void setSaveStrategy(SaveStrategy strategy) {
 		Assert.isLegal(strategy != null, Messages.RichTextWidget_Common_NullableStrategy_Error);
 		this.saveStrategy = strategy;
-	}
-
-	@Override
-	public boolean isDirty() {
-		EObject owner = getElement();
-		EStructuralFeature feature = getFeature();
-		String storedText = (String) owner.eGet(feature);
-		String text = getText();
-		if (storedText == null) {
-			return !"".equals(text);
-		}
-		return !storedText.equals(text);
 	}
 
 	@Override

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -116,11 +116,6 @@ public interface MDERichTextWidget extends PropertyChangeListener {
 	 * @param editable is the editable state
 	 */
 	void setEditable(boolean editable);
-
-	/**
-	 * @return if the widget is in dirty mode
-	 */
-	boolean isDirty();
 
 	/**
 	 * @return true if the editor is ready

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -198,14 +198,6 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 		}
 
 		return forceEditorUpdate;
-	}
-
-	@Override
-	public boolean isDirty() {
-		if (isReady() && isEditable()) {
-			return super.isDirty();
-		}
-		return false;
 	}
 
 	@Override

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -228,7 +228,7 @@ public class MDERichTextEditor extends EditorPart
 	@Override
 	public boolean isDirty() {
 		if (!isDeactivate()) {
-			return doCheckWorkspaceResourceStatus(widget) || widget.isDirty();
+      return doCheckWorkspaceResourceStatus(widget);
 		}
 		return false;
 	}

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/internal/ListenerInstaller.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/internal/ListenerInstaller.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -245,13 +245,10 @@ public class ListenerInstaller {
 		new BrowserFunction(widget.getBrowser(), "firePropertyChangeEvent") { //$NON-NLS-1$
 			@Override
 			public Object function(Object[] arguments) {
-				if (!widget.isDirtyStateUpdated() && widget.isDirty()) {
-					// As a performance improvement, the saveContent is only
-					// called only if the dirty state of the widget is not
-					// updated
-					widget.saveContent();
-					widget.setDirtyStateUpdated(true);
-				}
+        // Do nothing
+        // Do not save the content of the editor in the model
+        // Do not update the sate to dirty
+        // the state of the editor is linked to if the model is sync with what is edited in the editor
 				return null;
 			}
 		};


### PR DESCRIPTION
The rich text editor status is now only based on the Session status. In the scope of kitalpha/capella, AbstractMDERichTextWidget is only used from MDERichTextEditor.isDirty().
So I consider that MDERichTextWidget.isDirty() was badly managed and can be removed.
In the future, in the case we consider that MDERichTextWidget canc be used independently of MDERichTextEditor, perhaps we could have MDERichTextWidget.setDirty() and MDERichTextWidget.isDirty(). ListenerInstaller should
have BrowserFunction to listen to setText or insertText and call MDERichTextWidget.setDirty(boolean).

https://github.com/eclipse/kitalpha/issues/753