### PR TITLE
#753 Update the RichText editor status properly

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/impl/AbstractMDERichTextWidget.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/impl/AbstractMDERichTextWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -129,18 +129,6 @@ public abstract class AbstractMDERichTextWidget implements MDERichTextWidget {
 	public final void setSaveStrategy(SaveStrategy strategy) {
 		Assert.isLegal(strategy != null, Messages.RichTextWidget_Common_NullableStrategy_Error);
 		this.saveStrategy = strategy;
-	}
-
-	@Override
-	public boolean isDirty() {
-		EObject owner = getElement();
-		EStructuralFeature feature = getFeature();
-		String storedText = (String) owner.eGet(feature);
-		String text = getText();
-		if (storedText == null) {
-			return !"".equals(text);
-		}
-		return !storedText.equals(text);
 	}
 
 	@Override

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.common/src/org/polarsys/kitalpha/richtext/common/intf/MDERichTextWidget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -116,11 +116,6 @@ public interface MDERichTextWidget extends PropertyChangeListener {
 	 * @param editable is the editable state
 	 */
 	void setEditable(boolean editable);
-
-	/**
-	 * @return if the widget is in dirty mode
-	 */
-	boolean isDirty();
 
 	/**
 	 * @return true if the editor is ready

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
@@ -265,7 +265,7 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 					// We avoid to set several time the same text.
 					// With old descriptions, the text getText will be different to the given
 					// parameter as browser will refactor the HTML string
-					if (!currentValue.equals(text)) {
+          if (currentValue != null && !currentValue.equals(text)) {
 						editor.setText(text);
 					} else {
 						break;

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -198,14 +198,6 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 		}
 
 		return forceEditorUpdate;
-	}
-
-	@Override
-	public boolean isDirty() {
-		if (isReady() && isEditable()) {
-			return super.isDirty();
-		}
-		return false;
 	}
 
 	@Override

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2020 Thales Global Services S.A.S.
+ * Copyright (c) 2017, 2023 Thales Global Services S.A.S.
  *  This program and the accompanying materials are made available under the
  *  terms of the Eclipse Public License 2.0 which is available at
  *  http://www.eclipse.org/legal/epl-2.0
@@ -230,7 +230,7 @@ public class MDERichTextEditor extends EditorPart
 	@Override
 	public boolean isDirty() {
 		if (!isDeactivate()) {
-			return doCheckWorkspaceResourceStatus(widget) || widget.isDirty();
+      return doCheckWorkspaceResourceStatus(widget);
 		}
 		return false;
 	}

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget/src/org/polarsys/kitalpha/richtext/widget/editor/MDERichTextEditor.java
@@ -133,8 +133,10 @@ public class MDERichTextEditor extends EditorPart
 
 		if (eResource != null) {
 			IFile file = MDERichTextHelper.getFile(element);
-			String fileString = file.getFullPath().toString();
-			processResourceDelta(affectedChildren, fileString);
+			if (file != null) {
+			  String fileString = file.getFullPath().toString();
+			  processResourceDelta(affectedChildren, fileString);
+			}
 		} else {
 			Status status = new Status(IStatus.WARNING, Activator.PLUGIN_ID,
 					"Could nof find the resource of the editor: " + editorInput.getName());


### PR DESCRIPTION
The rich text editor status is now only based on the Session status. In the scope of kitalpha/capella, AbstractMDERichTextWidget is only used from MDERichTextEditor.isDirty().
So I consider that MDERichTextWidget.isDirty() was badly managed and can be removed.

Nevertheless, to keep the lock of the EObject being edited, a "change" Listener has been added to be notified when the content of the editor is changed.
The first change will call widget.saveContents() to be sure that the model is modified a soon as possible. (before it was done a little differently with the "key" listener)

https://github.com/eclipse/kitalpha/issues/753