### PR TITLE
#756 ModelElementLink label's whitespaces are now properly encoded

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget.ext/src/org/polarsys/kitalpha/richtext/widget/tools/ext/types/ModelElementLinkHandler.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget.ext/src/org/polarsys/kitalpha/richtext/widget/tools/ext/types/ModelElementLinkHandler.java
@@ -107,7 +107,9 @@ public class ModelElementLinkHandler extends AbstractModelOpenLink implements Li
 
 	@Override
 	public String encode(String url, String urlDisplayName) {
-		return "<a href=\"hlink://" + url + "\">" + StringEscapeUtils.escapeHtml(urlDisplayName) + "</a>"; //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+    String replaced = MDERichTextToolsHelper.encodeWhiteSpaces(StringEscapeUtils.escapeHtml(urlDisplayName));
+    return "<a href=\"hlink://" + url + "\">" + replaced //$NON-NLS-1$ //$NON-NLS-2$
+        + "</a>"; //$NON-NLS-1$
 	}
 
 	@Override
@@ -116,5 +118,4 @@ public class ModelElementLinkHandler extends AbstractModelOpenLink implements Li
 		url = url.replaceAll("/", ""); //$NON-NLS-1$ //$NON-NLS-2$
 		return url;
 	}
-
 }

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.widget.tools/src/org/polarsys/kitalpha/richtext/widget/tools/utils/MDERichTextToolsHelper.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.widget.tools/src/org/polarsys/kitalpha/richtext/widget/tools/utils/MDERichTextToolsHelper.java
@@ -11,6 +11,9 @@
  ******************************************************************************/
 package org.polarsys.kitalpha.richtext.widget.tools.utils;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.emf.common.util.EList;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.resource.Resource;
@@ -113,5 +116,19 @@ public class MDERichTextToolsHelper {
 		
 	}
 	
+  public static String encodeWhiteSpaces(String input) {
+    Matcher matcher = Pattern.compile("\\s+").matcher(input);
+    String replaced = matcher.replaceAll(match -> replaceAllWhiteSpacesButLast(match.group()));
+    return replaced;
+  }
+
+  private static String replaceAllWhiteSpacesButLast(String input) {
+    String result = "";
+    for (int i = 0; i < input.length() - 1; i++) {
+      result += "&nbsp;";
+    }
+    result += " ";
+    return result;
+  }
 	
 }


### PR DESCRIPTION
When a label contains multiple whitespaces in a row, they are now encoded using "&nbsp;" character (except the last whitespace) As it is already done when encoding the description text

Change-Id: I19e7214460d02176e3268d1519104b8203703e58