### PR TITLE
#764 Force RichText widgets to use IE on windows

### DIFF
--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/META-INF/MANIFEST.MF
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
-Bundle-SymbolicName: org.polarsys.kitalpha.richtext.nebula.widget
+Bundle-SymbolicName: org.polarsys.kitalpha.richtext.nebula.widget;singleton:=true
 Bundle-Version: 7.0.0.qualifier
 Bundle-Activator: org.polarsys.kitalpha.richtext.nebula.widget.internal.Activator
 Require-Bundle: org.eclipse.ui,

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/build.properties
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/build.properties
@@ -15,4 +15,5 @@ bin.includes = META-INF/,\
                .,\
                resources/,\
                OSGI-INF/,\
-               about.html
+               about.html,\
+               plugin.xml

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/plugin.xml
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/plugin.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="org.polarsys.kitalpha.richtext.nebula.widget.preferences.PreferenceInitializer">
+      </initializer>
+   </extension>
+
+</plugin>

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/MDENebulaBasedRichTextWidgetImpl.java
@@ -16,8 +16,10 @@ import java.net.URL;
 import java.util.Map;
 
 import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.nebula.widgets.richtext.RichTextEditor;
 import org.eclipse.nebula.widgets.richtext.RichTextEditorConfiguration;
+import org.eclipse.swt.SWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.browser.ProgressEvent;
 import org.eclipse.swt.browser.ProgressListener;
@@ -27,6 +29,8 @@ import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.polarsys.kitalpha.richtext.common.impl.BrowserBasedMDERichTextWidgetImpl;
 import org.polarsys.kitalpha.richtext.common.intf.MDERichTextWidget;
+import org.polarsys.kitalpha.richtext.nebula.widget.internal.Activator;
+import org.polarsys.kitalpha.richtext.nebula.widget.preferences.IRichTextPreferences;
 import org.polarsys.kitalpha.richtext.nebula.widget.toolbar.MDERichTextToolbarItemHandler;
 import org.polarsys.kitalpha.richtext.nebula.widget.toolbar.MDEToolbarItem;
 
@@ -57,7 +61,8 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 
 	public MDENebulaBasedRichTextWidgetImpl(Composite parent) {
 		super(parent);
-		this.editor = createRichTextEditor(parent, null, -1); // default configuration
+		int style = getBrowserStyle();
+		this.editor = createRichTextEditor(parent, null, style); // default configuration
 		this.configuration = getEditorConfiguration();
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(this.editor);
 
@@ -74,7 +79,8 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 		super(parent);
 		this.configuration = configuration;
 		((MDENebulaRichTextConfiguration) this.configuration).createToolbar();
-		this.editor = createRichTextEditor(parent, configuration, -1); // default
+		int style = getBrowserStyle();
+		this.editor = createRichTextEditor(parent, configuration, style); // default
 																		// configuration
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(this.editor);
 
@@ -89,6 +95,10 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 
 	public MDENebulaBasedRichTextWidgetImpl(Composite parent, int style) {
 		super(parent);
+		int browserStyle = getBrowserStyle();
+		if(browserStyle != -1) {
+			style = style & browserStyle;
+		}
 		this.editor = createRichTextEditor(parent, null, style); // default
 		// configuration
 		this.configuration = getEditorConfiguration();
@@ -107,6 +117,10 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 		super(parent);
 		this.configuration = configuration;
 		((MDENebulaRichTextConfiguration) this.configuration).createToolbar();
+		int browserStyle = getBrowserStyle();
+		if(browserStyle != -1) {
+			style = style & browserStyle;
+		}
 		this.editor = createRichTextEditor(parent, null, style); // default
 		// configuration
 		GridDataFactory.fillDefaults().grab(true, true).applyTo(this.editor);
@@ -433,5 +447,17 @@ public class MDENebulaBasedRichTextWidgetImpl extends BrowserBasedMDERichTextWid
 	@Override
 	public Composite getParent() {
 		return editor.getParent();
+	}
+	
+	protected int getBrowserStyle() {
+		int style = -1;
+		if(SWT.getPlatform().equals("win32")) {
+			IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+			boolean forceIE = preferenceStore.getBoolean(IRichTextPreferences.PREFERENCE_FORCE_IE_WIN32);
+			if(forceIE) {
+				style = SWT.WEBKIT;
+			}
+		}
+		return style;
 	}
 }

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/preferences/IRichTextPreferences.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/preferences/IRichTextPreferences.java
@@ -1,0 +1,8 @@
+package org.polarsys.kitalpha.richtext.nebula.widget.preferences;
+
+public interface IRichTextPreferences {
+	  /**
+	   * Preference related to enable or disable forcing the richtext widget to use IE on windows
+	   */
+	  public static final String PREFERENCE_FORCE_IE_WIN32 = "ForceIEOnRichTextWidgetWIN32"; //$NON-NLS-1$
+}

--- a/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/preferences/PreferenceInitializer.java
+++ b/richtext/plugins/org.polarsys.kitalpha.richtext.nebula.widget/src/org/polarsys/kitalpha/richtext/nebula/widget/preferences/PreferenceInitializer.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2023 THALES GLOBAL SERVICES.
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ * 
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *    THALES GLOBAL SERVICES - Initial API and implementation
+ *******************************************************************************/
+
+package org.polarsys.kitalpha.richtext.nebula.widget.preferences;
+
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.polarsys.kitalpha.richtext.nebula.widget.internal.Activator;
+
+public class PreferenceInitializer extends AbstractPreferenceInitializer {
+
+	/**
+     * 
+     */
+	public PreferenceInitializer() {
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer#initializeDefaultPreferences()
+	 */
+	@Override
+	public void initializeDefaultPreferences() {
+		IPreferenceStore preferenceStore = Activator.getDefault().getPreferenceStore();
+	    // Set default delay value.
+	    preferenceStore.setDefault(IRichTextPreferences.PREFERENCE_FORCE_IE_WIN32, true);
+	}
+
+}


### PR DESCRIPTION
Internet Explorer is needed as browser for richtext widgets, as Edge doesn't work properly yet

Change-Id: I7248f52452b45fd760a8443dfba0c67a49328d84