### PR TITLE
791 Load representations before running doc generation

### DIFF
--- a/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core.ui/src/org/polarsys/kitalpha/doc/gen/business/core/ui/helper/InvokeActivityHelper.java
+++ b/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core.ui/src/org/polarsys/kitalpha/doc/gen/business/core/ui/helper/InvokeActivityHelper.java
@@ -44,6 +44,7 @@ import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.progress.IProgressService;
 import org.polarsys.kitalpha.doc.gen.business.core.exceptions.DocgenRuntimeException;
+import org.polarsys.kitalpha.doc.gen.business.core.sirius.util.session.DiagramSessionHelper;
 import org.polarsys.kitalpha.doc.gen.business.core.ui.Messages;
 import org.polarsys.kitalpha.doc.gen.business.core.util.MonitorServices;
 
@@ -163,6 +164,8 @@ public class InvokeActivityHelper {
         try {
             MonitorServices.initMonitor(monitor);
             MonitorServices.init(0);
+            //Ensure that all representations are loaded
+            DiagramSessionHelper.getSessionDRepresentation();
             activityManager.invoke(monitor);
             activityManager.dispose();
             MonitorServices.dispose();


### PR DESCRIPTION
Ensure all representations are loaded before gendoc is ran As links are images might not be found

Change-Id: I68999a1456e76b3536a1f8d73de12ba9506760cc