### PR TITLE
#793 Images used in docgen are now disposed after the generation is

### DIFF
--- a/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/src/org/polarsys/kitalpha/doc/gen/business/core/util/GenDocExtendedImageRegistry.java
+++ b/Docgen/business/plugins/org.polarsys.kitalpha.doc.gen.business.core/src/org/polarsys/kitalpha/doc/gen/business/core/util/GenDocExtendedImageRegistry.java
@@ -12,6 +12,7 @@
 package org.polarsys.kitalpha.doc.gen.business.core.util;
 
 import org.eclipse.emf.edit.ui.provider.ExtendedImageRegistry;
+import org.eclipse.swt.graphics.Image;
 
 public class GenDocExtendedImageRegistry extends ExtendedImageRegistry {
 
@@ -22,6 +23,9 @@ public class GenDocExtendedImageRegistry extends ExtendedImageRegistry {
 	}
 
 	public void dispose() {
+		for(Image image : table.values()) {
+			image.dispose();
+		}
 		table.clear();
 	}
 }


### PR DESCRIPTION
completed

Fix swt leak where images used in docgen would not be disposed of

Change-Id: I142ea513ea59bd0cecb888e940ed4a2353080131